### PR TITLE
Fix stubtest by ignoring spurious NamedTuple errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: snake_egg/tests/*.py build venv
 	$(activate) && maturin develop && python snake_egg/tests/test_dataclass.py
 
 stubtest: snake_egg/__init__.pyi build venv
-	$(activate) && maturin develop --extras=dev && python -m mypy.stubtest snake_egg --ignore-missing-stub
+	$(activate) && maturin develop --extras=dev && python -m mypy.stubtest snake_egg --ignore-missing-stub --allowlist stubtest_allowlist
 
 mypy: snake_egg/__init__.pyi build venv
 	$(activate) && maturin develop --extras=dev && mypy snake_egg

--- a/stubtest_allowlist
+++ b/stubtest_allowlist
@@ -1,0 +1,1 @@
+.*NamedTuple.*


### PR DESCRIPTION
Stubtest was previously raising errors on the tests defined in the module by comparing the stubs for the built-in NamedTuple class with their runtime implementation. We did not implement this class and so we want to ignore any errors raised about it.

This error was raised in #7 but for some reason did not fail in CI until that was merged, so this is a follow-up PR.