### PR TITLE
Don't use stubtest in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         run: make build
       - name: Test
-        run: make test stubtest mypy
+        run: make test mypy
 
   # build-wheel:
   #   strategy:


### PR DESCRIPTION
The stubtest seems to have broken in #7. This disables it in CI for now, since the errors it raises are spurious.  It replaces #8, which was overly broad and didn't do what was intended.