### PR TITLE
Add publishing in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release -o dist
+          args: --release --sdist -o dist --find-interpreter
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -55,7 +55,7 @@ jobs:
       - uses: PyO3/maturin-action@v1.34.0
         with:
           command: build
-          args: --release -o dist
+          args: --release -o dist --find-interpreter
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -71,7 +71,7 @@ jobs:
       - uses: PyO3/maturin-action@v1.34.0
         with:
           command: build
-          args: --release -o dist --universal2
+          args: --release -o dist --universal2 --find-interpreter
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: [main]
+    tags:
+      - "*"
 jobs:
   test:
     strategy:
@@ -27,32 +29,72 @@ jobs:
       - name: Test
         run: make test mypy
 
-  # build-wheel:
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, macos-latest]
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.6
-  #         architecture: x64
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #     - name: Build Wheels
-  #       uses: messense/maturin-action@v1
-  #       with:
-  #         maturin-version: latest
-  #         manylinux: auto
-  #     - name: Install built wheel
-  #       run: |
-  #         pip install snake_egg --no-index --find-links ./target/wheels --force-reinstall
-  #         python -c "import snake_egg"
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: wheels
-  #         path: ./target/wheels
+  linux:
+    name: build linux
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: PyO3/maturin-action@v1.31.0
+        with:
+          manylinux: auto
+          command: build
+          args: --release --sdist -o dist --find-interpreter
+          # Pin rust toolchain, so it won't install 1.65.0, otherwise get this error:
+          # Attempting to include the sdist output tarball dist/egg_smol-0.1.0.tar.gz into itself! Check 'cargo package --list' output.
+          # https://github.com/metadsl/egg-smol-python/actions/runs/3388178229/jobs/5629843303
+          rust-toolchain: "1.64.0"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  windows:
+    name: build windows
+    runs-on: windows-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: PyO3/maturin-action@v1.31.0
+        with:
+          command: build
+          args: --release -o dist --find-interpreter
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  macos:
+    name: build macos
+    runs-on: macos-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: PyO3/maturin-action@v1.31.0
+        with:
+          command: build
+          args: --release -o dist --universal2 --find-interpreter
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [macos, windows, linux]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1.31.0
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --skip-existing *

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release  -o dist --find-interpreter
+          args: --release --sdist -o dist --find-interpreter
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --sdist -o dist --find-interpreter
+          args: --release -o dist
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -55,7 +55,7 @@ jobs:
       - uses: PyO3/maturin-action@v1.34.0
         with:
           command: build
-          args: --release -o dist --find-interpreter
+          args: --release -o dist
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -71,7 +71,7 @@ jobs:
       - uses: PyO3/maturin-action@v1.34.0
         with:
           command: build
-          args: --release -o dist --universal2 --find-interpreter
+          args: --release -o dist --universal2
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --sdist -o dist --find-interpreter
+          args: --release  -o dist --find-interpreter
           # Pin rust toolchain, so it won't install 1.65.0, otherwise get this error:
           # Attempting to include the sdist output tarball dist/egg_smol-0.1.0.tar.gz into itself! Check 'cargo package --list' output.
           # https://github.com/metadsl/egg-smol-python/actions/runs/3388178229/jobs/5629843303

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,15 +35,11 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     steps:
       - uses: actions/checkout@v3
-      - uses: PyO3/maturin-action@v1.31.0
+      - uses: PyO3/maturin-action@v1.34.0
         with:
           manylinux: auto
           command: build
           args: --release  -o dist --find-interpreter
-          # Pin rust toolchain, so it won't install 1.65.0, otherwise get this error:
-          # Attempting to include the sdist output tarball dist/egg_smol-0.1.0.tar.gz into itself! Check 'cargo package --list' output.
-          # https://github.com/metadsl/egg-smol-python/actions/runs/3388178229/jobs/5629843303
-          rust-toolchain: "1.64.0"
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -56,7 +52,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     steps:
       - uses: actions/checkout@v3
-      - uses: PyO3/maturin-action@v1.31.0
+      - uses: PyO3/maturin-action@v1.34.0
         with:
           command: build
           args: --release -o dist --find-interpreter
@@ -72,7 +68,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     steps:
       - uses: actions/checkout@v3
-      - uses: PyO3/maturin-action@v1.31.0
+      - uses: PyO3/maturin-action@v1.34.0
         with:
           command: build
           args: --release -o dist --universal2 --find-interpreter
@@ -92,7 +88,7 @@ jobs:
         with:
           name: wheels
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1.31.0
+        uses: PyO3/maturin-action@v1.34.0
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Python bindings for [`egg`](https://github.com/egraphs-good/egg)
 
 
+# Installing
+
+This package is published on PyPi and can be installed with `pip install snake-egg`.
+Wheels are built for Python version 3.7-3.10.
+
 # Venv
 
 The build system creates its own python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.11,<0.12"]
+requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
 dependencies = ["typing-extensions"]
 


### PR DESCRIPTION
This PR adds a CI task to publish build wheels and publish the package to PyPi on every git tag, closing #12.

The github actions are based on the [maturin template actions](https://github.com/PyO3/maturin/blob/main/src/templates/CI.yml.j2). 

It also upgrades maturing to the latest version, so that I can use the build args provided in that example.

To test this action, I created a `0.1.0` tag on my fork and ran the action. This published [the package on PyPi](https://pypi.org/project/snake-egg/) which is now available for install! I tested it locally on my mac.

Currently I am the only maintainor since I created the package, so please let me know who else to add. 

Then, a `PYPI_API_TOKEN` needs to be set on this repo, for someone's access key who has access to the repo, to use to publish it.

The [`maturin-action` repo lists more examples of CI scripts](https://github.com/PyO3/maturin-action#examples), which are all more complicated than the one I added here, which add support for building on different architectures. I am not that familiar with building Python wheels, so any suggestions/changes there are welcome.

TODO:
- [x] Add PYPI_API_TOKEN to fork
- [x] Create tag on fork branch to test publishing
- [x] Verify can install on my mac